### PR TITLE
Invert logic for connecting stdout, stdin, stderr

### DIFF
--- a/brew.py
+++ b/brew.py
@@ -61,9 +61,9 @@ class Brew(dotbot.Plugin):
                 cmd,
                 shell=True,
                 cwd=self._context.base_directory(),
-                stdin=devnull if defaults["stdin"] else None,
-                stdout=devnull if defaults["stdout"] else None,
-                stderr=devnull if defaults["stderr"] else None,
+                stdin=devnull if !defaults["stdin"] else None,
+                stdout=devnull if !defaults["stdout"] else None,
+                stderr=devnull if !defaults["stderr"] else None,
             )
 
     def _tap(self, tap_list, defaults) -> bool:

--- a/brew.py
+++ b/brew.py
@@ -61,9 +61,9 @@ class Brew(dotbot.Plugin):
                 cmd,
                 shell=True,
                 cwd=self._context.base_directory(),
-                stdin=devnull if !defaults["stdin"] else None,
-                stdout=devnull if !defaults["stdout"] else None,
-                stderr=devnull if !defaults["stderr"] else None,
+                stdin=devnull if not defaults["stdin"] else None,
+                stdout=devnull if not defaults["stdout"] else None,
+                stderr=devnull if not defaults["stderr"] else None,
             )
 
     def _tap(self, tap_list, defaults) -> bool:


### PR DESCRIPTION
If I understand the intention correctly, the `stdout`, `stdin`, `stderr` boolean options are meant to be `True` in order to connect these streams of the subprocess to the parent process. This behavior was not working, and this change is meant to fix that.

The Python [subprocess](https://docs.python.org/3/library/subprocess.html) docs explain that using the `None` value will achieve connecting the streams. The existing code only used `None` when the passed in option was `True` (and `os.devnull` otherwise). Therefore, inverting the logic should result in the intended behavior.