### PR TITLE
Allow overriding STDIN, STDOUT and STDERR for invoking cmds and make brew install command work

### DIFF
--- a/brew.py
+++ b/brew.py
@@ -61,9 +61,9 @@ class Brew(dotbot.Plugin):
                 cmd,
                 shell=True,
                 cwd=self._context.base_directory(),
-                stdin=devnull if defaults["stdin"] else None,
-                stdout=devnull if defaults["stdout"] else None,
-                stderr=devnull if defaults["stderr"] else None,
+                stdin=True if defaults["stdin"] else devnull,
+                stdout=True if defaults["stdout"] else devnull,
+                stderr=True if defaults["stderr"] else devnull,
             )
 
     def _tap(self, tap_list, defaults) -> bool:

--- a/brew.py
+++ b/brew.py
@@ -40,7 +40,7 @@ class Brew(dotbot.Plugin):
                 "stdout": True,
                 "force_intel": False,
             },
-            "binstall-brew": {
+            "install-brew": {
                 "stdin": True,
                 "stderr": True,
                 "stdout": True,

--- a/brew.py
+++ b/brew.py
@@ -40,6 +40,12 @@ class Brew(dotbot.Plugin):
                 "stdout": True,
                 "force_intel": False,
             },
+            "binstall-brew": {
+                "stdin": True,
+                "stderr": True,
+                "stdout": True,
+                "force_intel": False,
+            },
         }
         super().__init__(*args, **kwargs)
 
@@ -178,5 +184,5 @@ class Brew(dotbot.Plugin):
             return False
 
         link = "https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh"
-        cmd = f'command -v brew >/dev/null || /bin/bash -c "$(curl -fsSL {link})"'
+        cmd = f'/bin/bash -c "$(curl -fsSL {link})"'
         return self._install(cmd, 'command -v brew', 'brew', defaults)


### PR DESCRIPTION
Hi there,

I have just started redoing my dotfiles and I noticed that regardless of what I put into the `defaults` for `stdout` and `stderr`. I compared the implementation with other plugins and I noticed that here `devnull` was always passed in, when `stdout: True` was set in the defaults, and `None` otherwise. This should be the other way around and this PR changes this.

Also, the command to install brew did fail silently because it will ask for your password. So enabling STDOUT and and -IN for the brew installation fixes this issue